### PR TITLE
fix_ambient_music_bug

### DIFF
--- a/Source/Redemption/Private/AudioManager.cpp
+++ b/Source/Redemption/Private/AudioManager.cpp
@@ -75,13 +75,14 @@ void AAudioManager::PlayAmbientMusic()
 
 void AAudioManager::PlayCombatMusic()
 {
+    // Clear any pending switch back to ambient music, even if we are not restarting the music
+    GetWorldTimerManager().ClearTimer(MusicDelayTimerHandle);
+
     // Only switch to combat music if we're not already in combat mode
     if (CombatMusicCue != nullptr && !bIsInCombat)
     {
         bIsInCombat = true;
-        // Clear any pending switch back to ambient music
-        GetWorldTimerManager().ClearTimer(MusicDelayTimerHandle);
-
+        
         // Set the combat music and play it
         MusicComponent->SetSound(CombatMusicCue);
         MusicComponent->Play();


### PR DESCRIPTION
the bug was cause by an oversight on my side when I fixed another bug before. If we reset the timer only if the music is in combat we have a problem of not resetting it if the player enter the view of the rat before the music stops but after the timer has been set